### PR TITLE
段階2&3完了: サンプルデータ表示機能とニュース詳細画面の実装

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -42,6 +42,7 @@ kotlin {
             implementation(compose.ui)
             implementation(compose.components.resources)
             implementation(compose.components.uiToolingPreview)
+            implementation(libs.kotlinx.coroutines.core)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -1,10 +1,36 @@
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import presentation.screen.NewsListScreen
+import presentation.screen.NewsDetailScreen
 import theme.LaLigaNewsTheme
+
+sealed class Screen {
+    object NewsList : Screen()
+    data class NewsDetail(val articleId: String) : Screen()
+}
 
 @Composable
 fun App() {
+    var currentScreen by remember { mutableStateOf<Screen>(Screen.NewsList) }
+    
     LaLigaNewsTheme {
-        NewsListScreen()
+        when (currentScreen) {
+            is Screen.NewsList -> {
+                NewsListScreen(
+                    onNewsClick = { articleId ->
+                        currentScreen = Screen.NewsDetail(articleId)
+                    }
+                )
+            }
+            
+            is Screen.NewsDetail -> {
+                val detailScreen = currentScreen as Screen.NewsDetail
+                NewsDetailScreen(
+                    articleId = detailScreen.articleId,
+                    onBackClick = {
+                        currentScreen = Screen.NewsList
+                    }
+                )
+            }
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/data/model/NewsArticle.kt
+++ b/composeApp/src/commonMain/kotlin/data/model/NewsArticle.kt
@@ -4,6 +4,12 @@ data class NewsArticle(
     val id: String,
     val title: String,
     val summary: String,
-    val imageUrl: String,
-    val publishDate: String
-)
+    val content: String,
+    val imageUrls: List<String>,
+    val publishDateTime: String,
+    val source: String,
+    val originalLanguage: String,
+    val isTranslated: Boolean
+) {
+    val primaryImageUrl: String get() = imageUrls.firstOrNull() ?: ""
+}

--- a/composeApp/src/commonMain/kotlin/data/model/NewsArticle.kt
+++ b/composeApp/src/commonMain/kotlin/data/model/NewsArticle.kt
@@ -1,0 +1,9 @@
+package data.model
+
+data class NewsArticle(
+    val id: String,
+    val title: String,
+    val summary: String,
+    val imageUrl: String,
+    val publishDate: String
+)

--- a/composeApp/src/commonMain/kotlin/data/repository/NewsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/data/repository/NewsRepository.kt
@@ -1,0 +1,7 @@
+package data.repository
+
+import data.model.NewsArticle
+
+interface NewsRepository {
+    suspend fun getNewsList(): List<NewsArticle>
+}

--- a/composeApp/src/commonMain/kotlin/data/repository/SampleNewsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/data/repository/SampleNewsRepository.kt
@@ -9,71 +9,143 @@ class SampleNewsRepository : NewsRepository {
                 id = "1",
                 title = "レアル・マドリード、エル・クラシコで圧勝",
                 summary = "サンティアゴ・ベルナベウでの一戦でレアル・マドリードがバルセロナを3-0で下しました。",
-                imageUrl = "https://images.unsplash.com/photo-1551698618-1dfe5d97d256?w=400&h=300&fit=crop",
-                publishDate = "2024-03-15"
+                content = "サンティアゴ・ベルナベウで行われたエル・クラシコは、レアル・マドリードがバルセロナを3-0で完勝する結果となった。\n\n前半15分、ヴィニシウス・ジュニオールが先制ゴールを記録。その後も攻撃の手を緩めないマドリードは、35分にベンゼマが追加点を奪った。\n\n後半に入ってもマドリードの勢いは止まらず、70分にはモドリッチの見事なミドルシュートがネットを揺らし3-0とした。バルセロナも反撃を試みたが、マドリードの堅固な守備を破ることはできなかった。\n\nこの勝利により、マドリードはリーグ首位をより確固たるものとし、シーズン終盤に向けて大きな弾みをつけることとなった。アンチェロッティ監督は試合後、「チーム全体の献身的なプレーが勝利につながった」とコメントしている。",
+                imageUrls = listOf(
+                    "https://images.unsplash.com/photo-1551698618-1dfe5d97d256?w=400&h=300&fit=crop",
+                    "https://images.unsplash.com/photo-1574629810360-7efbbe195018?w=400&h=300&fit=crop",
+                    "https://images.unsplash.com/photo-1522778119026-d647f0596c20?w=400&h=300&fit=crop"
+                ),
+                publishDateTime = "2024-03-15 22:30",
+                source = "ESPN",
+                originalLanguage = "日本語",
+                isTranslated = false
             ),
             NewsArticle(
                 id = "2",
                 title = "バルセロナ、新戦力ガビが大活躍",
                 summary = "カンプ・ノウでの試合でガビが2ゴールを決め、チームの勝利に貢献しました。",
-                imageUrl = "https://images.unsplash.com/photo-1529900748604-07564a03e7a6?w=400&h=300&fit=crop",
-                publishDate = "2024-03-14"
+                content = "カンプ・ノウで行われたラ・リーガ第28節で、バルセロナが新戦力ガビの活躍により3-1で勝利を収めた。\n\n19歳のガビは前半20分と後半55分に立て続けにゴールを決め、チームの勝利に大きく貢献した。特に2点目のゴールは、ペドリからの絶妙なパスを受けての見事なボレーシュートで、スタジアムを大いに沸かせた。\n\n監督のシャビは試合後、「ガビは我々の将来を担う選手だ。今日のプレーがそれを証明している」と若手の成長を賞賛した。\n\nこの勝利によりバルセロナはリーグ戦での連勝を3試合に伸ばし、上位争いにおいて重要な3ポイントを獲得することとなった。次節も引き続きガビの活躍に期待が集まる。",
+                imageUrls = listOf(
+                    "https://images.unsplash.com/photo-1529900748604-07564a03e7a6?w=400&h=300&fit=crop"
+                ),
+                publishDateTime = "2024-03-14 21:45",
+                source = "Goal.com",
+                originalLanguage = "日本語",
+                isTranslated = false
             ),
             NewsArticle(
                 id = "3",
-                title = "アトレティコ・マドリード、連勝記録更新",
+                title = "Atlético Madrid extends winning streak",
                 summary = "ワンダ・メトロポリターノでの試合でアトレティコが5連勝を達成しました。",
-                imageUrl = "https://images.unsplash.com/photo-1522778119026-d647f0596c20?w=400&h=300&fit=crop",
-                publishDate = "2024-03-13"
+                content = "Atlético Madrid continued their impressive form with a 2-0 victory at the Wanda Metropolitano, extending their winning streak to five games.\n\nThe match saw brilliant performances from key players, with goals coming in the second half. The team's defensive solidity has been particularly noteworthy during this winning run, having conceded only two goals in their last five matches.\n\nManager Diego Simeone praised his team's consistency and determination. 'The players are showing great commitment and understanding of our tactical approach,' he said in the post-match interview.\n\nThis victory strengthens Atlético's position in the league table and demonstrates their strong form heading into the crucial final weeks of the season. The team's supporters were in full voice throughout the match, creating an electric atmosphere that clearly motivated the players.",
+                imageUrls = listOf(
+                    "https://images.unsplash.com/photo-1522778119026-d647f0596c20?w=400&h=300&fit=crop",
+                    "https://images.unsplash.com/photo-1489944440615-453fc2b6a9a9?w=400&h=300&fit=crop"
+                ),
+                publishDateTime = "2024-03-13 20:15",
+                source = "Marca",
+                originalLanguage = "英語",
+                isTranslated = true
             ),
             NewsArticle(
                 id = "4",
                 title = "セビージャFC、ヨーロッパリーグ進出決定",
                 summary = "ラ・リーガでの健闘によりセビージャがヨーロッパリーグ出場権を獲得しました。",
-                imageUrl = "https://images.unsplash.com/photo-1574629810360-7efbbe195018?w=400&h=300&fit=crop",
-                publishDate = "2024-03-12"
+                content = "セビージャFCが今シーズンのラ・リーガでの健闘により、来シーズンのヨーロッパリーグ出場権を獲得した。\n\n残り数試合を残して数学的に出場権を確定させたセビージャは、今シーズン安定した戦いを見せている。特に守備陣の連携が素晴らしく、失点数はリーグでも上位に位置している。\n\n監督のメンディリバルは「チーム全体の努力が実を結んだ。選手たちは素晴らしい集中力を見せてくれた」と語った。\n\nクラブにとってヨーロッパリーグは得意な舞台でもあり、ファンは来シーズンの活躍を期待している。また、この出場権獲得により、夏の移籍市場でもより良い選手を獲得できる可能性が高まった。",
+                imageUrls = listOf(
+                    "https://images.unsplash.com/photo-1574629810360-7efbbe195018?w=400&h=300&fit=crop",
+                    "https://images.unsplash.com/photo-1508098682722-e99c43a406b2?w=400&h=300&fit=crop",
+                    "https://images.unsplash.com/photo-1543326727-cf6c39e8f84c?w=400&h=300&fit=crop",
+                    "https://images.unsplash.com/photo-1553778263-73a83bab9b0c?w=400&h=300&fit=crop"
+                ),
+                publishDateTime = "2024-03-12 19:30",
+                source = "AS",
+                originalLanguage = "日本語",
+                isTranslated = false
             ),
             NewsArticle(
                 id = "5",
-                title = "ビルバオ、コパ・デル・レイ準決勝進出",
+                title = "Athletic Bilbao reaches Copa del Rey semifinals",
                 summary = "アスレティック・ビルバオがコパ・デル・レイ準決勝への切符を手にしました。",
-                imageUrl = "https://images.unsplash.com/photo-1431324155629-1a6deb1dec8d?w=400&h=300&fit=crop",
-                publishDate = "2024-03-11"
+                content = "Athletic Bilbao secured their place in the Copa del Rey semifinals with a thrilling 2-1 victory over their opponents in a match that showcased the best of Spanish football.\n\nThe Basque side showed great character throughout the match, particularly in the second half when they overturned a 1-0 deficit. The winning goal came in the 85th minute, sending the traveling fans into raptures.\n\nThis achievement is particularly significant for Athletic Bilbao, as the Copa del Rey holds special importance for the club and its supporters. The team's unique philosophy of only fielding Basque players makes every success even more meaningful.\n\nCoach Ernesto Valverde expressed his pride in the team's performance: 'The players showed the true spirit of Athletic today. This is what our club represents - passion, determination, and never giving up.'\n\nThe semifinal draw will determine their next opponents as they continue their quest for Copa del Rey glory.",
+                imageUrls = listOf(
+                    "https://images.unsplash.com/photo-1431324155629-1a6deb1dec8d?w=400&h=300&fit=crop",
+                    "https://images.unsplash.com/photo-1544717684-b6a26df9e6b8?w=400&h=300&fit=crop"
+                ),
+                publishDateTime = "2024-03-11 22:00",
+                source = "Sky Sports",
+                originalLanguage = "英語",
+                isTranslated = true
             ),
             NewsArticle(
                 id = "6",
-                title = "レアル・ソシエダ、若手選手が躍進",
+                title = "Real Sociedad: joven talento en ascenso",
                 summary = "20歳のMFが今シーズン5得点目を記録し、チームの躍進に貢献しています。",
-                imageUrl = "https://images.unsplash.com/photo-1543326727-cf6c39e8f84c?w=400&h=300&fit=crop",
-                publishDate = "2024-03-10"
+                content = "La Real Sociedad continúa con su excelente temporada, y mucho de ello se debe al surgimiento de jóvenes talentos en el equipo. El mediocampista de 20 años ha sido una revelación esta temporada.\n\nCon su quinto gol de la temporada, el joven jugador ha demostrado que puede ser una pieza clave en el futuro del club. Su técnica, visión de juego y capacidad goleadora lo convierten en uno de los prospectos más prometedores del fútbol español.\n\nEl entrenador Imanol Alguacil ha elogiado constantemente el desarrollo del jugador: 'Su progreso ha sido excepcional. Tiene la mentalidad correcta y el talento necesario para llegar muy lejos.'\n\nLa afición de la Real Sociedad está emocionada con este nuevo talento, que representa la cantera del club y sus valores de desarrollar jugadores locales. Su rendimiento esta temporada ha sido crucial para mantener al equipo en posiciones europeas.",
+                imageUrls = listOf(
+                    "https://images.unsplash.com/photo-1543326727-cf6c39e8f84c?w=400&h=300&fit=crop"
+                ),
+                publishDateTime = "2024-03-10 18:45",
+                source = "Mundo Deportivo",
+                originalLanguage = "スペイン語",
+                isTranslated = true
             ),
             NewsArticle(
                 id = "7",
                 title = "バレンシアCF、ホームで劇的勝利",
                 summary = "メスタージャでの一戦で90分にゴールを決め、2-1の勝利を収めました。",
-                imageUrl = "https://images.unsplash.com/photo-1508098682722-e99c43a406b2?w=400&h=300&fit=crop",
-                publishDate = "2024-03-09"
+                content = "メスタージャで行われた激戦は、バレンシアCFが劇的な勝利を収める結果となった。90分に決勝ゴールを決めたのは、今シーズン加入したばかりの新外国人選手だった。\n\n試合は前半から白熱した展開となり、両チームがゴールを狙い続けた。バレンシアが先制したものの、相手チームもすぐに同点ゴールを決め、1-1で後半に入った。\n\n後半は両チーム一歩も譲らない展開が続いたが、アディショナルタイムに入ってからバレンシアが決定的なチャンスを迎えた。コーナーキックからのこぼれ球を、新加入選手が冷静に押し込み劇的な勝利を演出した。\n\nこの勝利により、バレンシアは重要な勝ち点3を獲得し、リーグ戦での順位を大きく上げることとなった。ファンにとっても記憶に残る素晴らしい試合となった。",
+                imageUrls = listOf(
+                    "https://images.unsplash.com/photo-1508098682722-e99c43a406b2?w=400&h=300&fit=crop",
+                    "https://images.unsplash.com/photo-1551698618-1dfe5d97d256?w=400&h=300&fit=crop",
+                    "https://images.unsplash.com/photo-1522778119026-d647f0596c20?w=400&h=300&fit=crop"
+                ),
+                publishDateTime = "2024-03-09 21:15",
+                source = "Super Deporte",
+                originalLanguage = "日本語",
+                isTranslated = false
             ),
             NewsArticle(
                 id = "8",
                 title = "ビジャレアル、チャンピオンズリーグ圏内浮上",
                 summary = "エスタディオ・デ・ラ・セラミカでの勝利によりCL圏内の4位に浮上しました。",
-                imageUrl = "https://images.unsplash.com/photo-1553778263-73a83bab9b0c?w=400&h=300&fit=crop",
-                publishDate = "2024-03-08"
+                content = "エスタディオ・デ・ラ・セラミカで行われた重要な一戦で、ビジャレアルが見事な勝利を収め、念願のチャンピオンズリーグ圏内である4位に浮上した。\n\n今シーズンのビジャレアルは一貫して安定したパフォーマンスを見せており、特に攻撃陣の連携が素晴らしい。今回の試合でも、前半から積極的な攻撃を仕掛け、相手守備陣を翻弄し続けた。\n\n監督のエメリは「チームが成長し続けている証拠だ。選手たちの努力と献身が今日の結果につながった」と満足の表情を見せた。\n\nこの順位により、来シーズンのチャンピオンズリーグ出場に大きく近づいたビジャレアル。残り試合も重要な戦いが続くが、この勢いを維持できれば目標達成も現実的になってきた。ファンにとっても夢のような展開が続いている。",
+                imageUrls = listOf(
+                    "https://images.unsplash.com/photo-1553778263-73a83bab9b0c?w=400&h=300&fit=crop",
+                    "https://images.unsplash.com/photo-1574629810360-7efbbe195018?w=400&h=300&fit=crop"
+                ),
+                publishDateTime = "2024-03-08 20:30",
+                source = "Villarreal CF公式",
+                originalLanguage = "日本語",
+                isTranslated = false
             ),
             NewsArticle(
                 id = "9",
                 title = "ラス・パルマス、昇格後初勝利",
                 summary = "1部復帰後苦戦していたラス・パルマスがようやく今季初勝利を挙げました。",
-                imageUrl = "https://images.unsplash.com/photo-1489944440615-453fc2b6a9a9?w=400&h=300&fit=crop",
-                publishDate = "2024-03-07"
+                content = "長い間勝利から遠ざかっていたラス・パルマスが、ついに今シーズン初勝利を挙げることができた。1部復帰後の厳しい戦いが続いていたが、チーム一丸となって掴んだ貴重な3ポイントだった。\n\n試合は序盤から激しい展開となり、両チームが積極的に攻撃を仕掛けた。ラス・パルマスは前半に先制ゴールを決め、後半も集中力を切らすことなく守り抜いた。\n\n勝利の瞬間、スタジアムは大きな歓声に包まれ、選手たちも感極まった表情を見せた。監督は「この勝利は選手、スタッフ、そしてファンみんなの努力の結果だ」と涙ながらにコメントした。\n\nこの勝利により、ラス・パルマスは残留争いにおいて重要な一歩を踏み出すことができた。チームの士気も大幅に向上し、今後の戦いに向けて大きな弾みとなることは間違いない。",
+                imageUrls = listOf(
+                    "https://images.unsplash.com/photo-1489944440615-453fc2b6a9a9?w=400&h=300&fit=crop",
+                    "https://images.unsplash.com/photo-1431324155629-1a6deb1dec8d?w=400&h=300&fit=crop",
+                    "https://images.unsplash.com/photo-1544717684-b6a26df9e6b8?w=400&h=300&fit=crop"
+                ),
+                publishDateTime = "2024-03-07 19:00",
+                source = "Canarias7",
+                originalLanguage = "日本語",
+                isTranslated = false
             ),
             NewsArticle(
                 id = "10",
                 title = "ヘタフェ、堅守で勝ち点3を獲得",
                 summary = "コリセウム・アルフォンソ・ペレスでヘタフェが1-0の勝利を収めました。",
-                imageUrl = "https://images.unsplash.com/photo-1544717684-b6a26df9e6b8?w=400&h=300&fit=crop",
-                publishDate = "2024-03-06"
+                content = "コリセウム・アルフォンソ・ペレスで行われた試合で、ヘタフェが堅固な守備を武器に1-0の勝利を収めた。今シーズンのヘタフェの特徴でもある組織的な守備が今回も見事に機能した。\n\n試合は前半から両チームが慎重な戦術を選択し、なかなかゴールが生まれない膠着状態が続いた。しかし、後半に入ってからヘタフェが徐々にペースを掴み始めた。\n\n決勝ゴールは75分、セットプレーからのヘディングシュートだった。守備的な戦術で知られるヘタフェだが、この試合では攻撃でも良い形を作ることができていた。\n\n監督のボルダラスは「我々のスタイルを貫いた結果だ。選手たちは戦術を完璧に理解し、実行してくれた」と語った。この勝利により、ヘタフェは中位での安定した順位を確保することができた。",
+                imageUrls = listOf(
+                    "https://images.unsplash.com/photo-1544717684-b6a26df9e6b8?w=400&h=300&fit=crop"
+                ),
+                publishDateTime = "2024-03-06 17:30",
+                source = "Getafe CF公式",
+                originalLanguage = "日本語",
+                isTranslated = false
             )
         )
     }

--- a/composeApp/src/commonMain/kotlin/data/repository/SampleNewsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/data/repository/SampleNewsRepository.kt
@@ -1,0 +1,80 @@
+package data.repository
+
+import data.model.NewsArticle
+
+class SampleNewsRepository : NewsRepository {
+    override suspend fun getNewsList(): List<NewsArticle> {
+        return listOf(
+            NewsArticle(
+                id = "1",
+                title = "レアル・マドリード、エル・クラシコで圧勝",
+                summary = "サンティアゴ・ベルナベウでの一戦でレアル・マドリードがバルセロナを3-0で下しました。",
+                imageUrl = "https://images.unsplash.com/photo-1551698618-1dfe5d97d256?w=400&h=300&fit=crop",
+                publishDate = "2024-03-15"
+            ),
+            NewsArticle(
+                id = "2",
+                title = "バルセロナ、新戦力ガビが大活躍",
+                summary = "カンプ・ノウでの試合でガビが2ゴールを決め、チームの勝利に貢献しました。",
+                imageUrl = "https://images.unsplash.com/photo-1529900748604-07564a03e7a6?w=400&h=300&fit=crop",
+                publishDate = "2024-03-14"
+            ),
+            NewsArticle(
+                id = "3",
+                title = "アトレティコ・マドリード、連勝記録更新",
+                summary = "ワンダ・メトロポリターノでの試合でアトレティコが5連勝を達成しました。",
+                imageUrl = "https://images.unsplash.com/photo-1522778119026-d647f0596c20?w=400&h=300&fit=crop",
+                publishDate = "2024-03-13"
+            ),
+            NewsArticle(
+                id = "4",
+                title = "セビージャFC、ヨーロッパリーグ進出決定",
+                summary = "ラ・リーガでの健闘によりセビージャがヨーロッパリーグ出場権を獲得しました。",
+                imageUrl = "https://images.unsplash.com/photo-1574629810360-7efbbe195018?w=400&h=300&fit=crop",
+                publishDate = "2024-03-12"
+            ),
+            NewsArticle(
+                id = "5",
+                title = "ビルバオ、コパ・デル・レイ準決勝進出",
+                summary = "アスレティック・ビルバオがコパ・デル・レイ準決勝への切符を手にしました。",
+                imageUrl = "https://images.unsplash.com/photo-1431324155629-1a6deb1dec8d?w=400&h=300&fit=crop",
+                publishDate = "2024-03-11"
+            ),
+            NewsArticle(
+                id = "6",
+                title = "レアル・ソシエダ、若手選手が躍進",
+                summary = "20歳のMFが今シーズン5得点目を記録し、チームの躍進に貢献しています。",
+                imageUrl = "https://images.unsplash.com/photo-1543326727-cf6c39e8f84c?w=400&h=300&fit=crop",
+                publishDate = "2024-03-10"
+            ),
+            NewsArticle(
+                id = "7",
+                title = "バレンシアCF、ホームで劇的勝利",
+                summary = "メスタージャでの一戦で90分にゴールを決め、2-1の勝利を収めました。",
+                imageUrl = "https://images.unsplash.com/photo-1508098682722-e99c43a406b2?w=400&h=300&fit=crop",
+                publishDate = "2024-03-09"
+            ),
+            NewsArticle(
+                id = "8",
+                title = "ビジャレアル、チャンピオンズリーグ圏内浮上",
+                summary = "エスタディオ・デ・ラ・セラミカでの勝利によりCL圏内の4位に浮上しました。",
+                imageUrl = "https://images.unsplash.com/photo-1553778263-73a83bab9b0c?w=400&h=300&fit=crop",
+                publishDate = "2024-03-08"
+            ),
+            NewsArticle(
+                id = "9",
+                title = "ラス・パルマス、昇格後初勝利",
+                summary = "1部復帰後苦戦していたラス・パルマスがようやく今季初勝利を挙げました。",
+                imageUrl = "https://images.unsplash.com/photo-1489944440615-453fc2b6a9a9?w=400&h=300&fit=crop",
+                publishDate = "2024-03-07"
+            ),
+            NewsArticle(
+                id = "10",
+                title = "ヘタフェ、堅守で勝ち点3を獲得",
+                summary = "コリセウム・アルフォンソ・ペレスでヘタフェが1-0の勝利を収めました。",
+                imageUrl = "https://images.unsplash.com/photo-1544717684-b6a26df9e6b8?w=400&h=300&fit=crop",
+                publishDate = "2024-03-06"
+            )
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/presentation/component/NewsItemCard.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/component/NewsItemCard.kt
@@ -1,0 +1,99 @@
+package presentation.component
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import data.model.NewsArticle
+
+@Composable
+fun NewsItemCard(
+    article: NewsArticle,
+    onClick: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    Card(
+        onClick = onClick,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // 画像プレースホルダー（現在は色付きのBoxで代用）
+            Box(
+                modifier = Modifier
+                    .size(80.dp)
+                    .clip(RoundedCornerShape(8.dp)),
+                contentAlignment = Alignment.Center
+            ) {
+                Card(
+                    modifier = Modifier.fillMaxSize(),
+                    colors = CardDefaults.cardColors(containerColor = Color.LightGray)
+                ) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "画像",
+                            fontSize = 12.sp,
+                            color = Color.DarkGray
+                        )
+                    }
+                }
+            }
+            
+            Spacer(modifier = Modifier.width(12.dp))
+            
+            // テキスト情報
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+            ) {
+                Text(
+                    text = article.title,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.Black,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                
+                Spacer(modifier = Modifier.height(4.dp))
+                
+                Text(
+                    text = article.summary,
+                    fontSize = 14.sp,
+                    color = Color.Gray,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                
+                Spacer(modifier = Modifier.height(4.dp))
+                
+                Text(
+                    text = article.publishDate,
+                    fontSize = 12.sp,
+                    color = Color.Gray
+                )
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/presentation/component/NewsItemCard.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/component/NewsItemCard.kt
@@ -89,7 +89,7 @@ fun NewsItemCard(
                 Spacer(modifier = Modifier.height(4.dp))
                 
                 Text(
-                    text = article.publishDate,
+                    text = article.publishDateTime.split(" ")[0], // 日付部分のみ表示
                     fontSize = 12.sp,
                     color = Color.Gray
                 )

--- a/composeApp/src/commonMain/kotlin/presentation/screen/NewsDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screen/NewsDetailScreen.kt
@@ -1,0 +1,274 @@
+package presentation.screen
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import data.model.NewsArticle
+import data.repository.SampleNewsRepository
+import theme.LaLigaRed
+import theme.White
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NewsDetailScreen(
+    articleId: String,
+    onBackClick: () -> Unit
+) {
+    val repository = remember { SampleNewsRepository() }
+    var article by remember { mutableStateOf<NewsArticle?>(null) }
+    var isLoading by remember { mutableStateOf(true) }
+    
+    LaunchedEffect(articleId) {
+        try {
+            val articles = repository.getNewsList()
+            article = articles.find { it.id == articleId }
+        } catch (e: Exception) {
+            // エラーハンドリング
+        } finally {
+            isLoading = false
+        }
+    }
+    
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(White)
+    ) {
+        // ヘッダー
+        TopAppBar(
+            title = {
+                Text(
+                    text = article?.title?.take(20) ?: "記事詳細",
+                    color = White,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1
+                )
+            },
+            navigationIcon = {
+                IconButton(onClick = onBackClick) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "戻る",
+                        tint = White
+                    )
+                }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = LaLigaRed
+            )
+        )
+        
+        when {
+            isLoading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(color = LaLigaRed)
+                }
+            }
+            
+            article == null -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = "記事が見つかりません",
+                            fontSize = 16.sp,
+                            color = Color.Red
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Button(
+                            onClick = onBackClick,
+                            colors = ButtonDefaults.buttonColors(containerColor = LaLigaRed)
+                        ) {
+                            Text("戻る", color = White)
+                        }
+                    }
+                }
+            }
+            
+            else -> {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    // 記事タイトル
+                    Text(
+                        text = article!!.title,
+                        fontSize = 24.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.Black,
+                        modifier = Modifier.padding(16.dp)
+                    )
+                    
+                    // 画像スライドショー
+                    if (article!!.imageUrls.isNotEmpty()) {
+                        ImageSlideshow(
+                            imageUrls = article!!.imageUrls,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(200.dp)
+                        )
+                    }
+                    
+                    // メタデータ
+                    Column(
+                        modifier = Modifier.padding(16.dp)
+                    ) {
+                        Text(
+                            text = "公開日時: ${article!!.publishDateTime}",
+                            fontSize = 12.sp,
+                            color = Color.Gray
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = "ソース: ${article!!.source}",
+                            fontSize = 12.sp,
+                            color = Color.Gray
+                        )
+                        if (article!!.isTranslated) {
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                text = "※ ${article!!.originalLanguage}から翻訳されました",
+                                fontSize = 12.sp,
+                                color = Color.Blue,
+                                fontStyle = androidx.compose.ui.text.font.FontStyle.Italic
+                            )
+                        }
+                    }
+                    
+                    Divider(
+                        color = Color.LightGray,
+                        thickness = 1.dp,
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                    
+                    // 記事本文
+                    Text(
+                        text = article!!.content,
+                        fontSize = 16.sp,
+                        lineHeight = 24.sp,
+                        color = Color.Black,
+                        modifier = Modifier.padding(16.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun ImageSlideshow(
+    imageUrls: List<String>,
+    modifier: Modifier = Modifier
+) {
+    if (imageUrls.size == 1) {
+        // 画像が1枚の場合は単純表示
+        Box(
+            modifier = modifier
+                .padding(horizontal = 16.dp)
+                .clip(RoundedCornerShape(8.dp)),
+            contentAlignment = Alignment.Center
+        ) {
+            Card(
+                modifier = Modifier.fillMaxSize(),
+                colors = CardDefaults.cardColors(containerColor = Color.LightGray)
+            ) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "画像",
+                        fontSize = 16.sp,
+                        color = Color.DarkGray
+                    )
+                }
+            }
+        }
+    } else {
+        // 複数画像の場合はスライドショー
+        val pagerState = rememberPagerState(pageCount = { imageUrls.size })
+        
+        Column(modifier = modifier) {
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .padding(horizontal = 16.dp)
+            ) { page ->
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(RoundedCornerShape(8.dp)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Card(
+                        modifier = Modifier.fillMaxSize(),
+                        colors = CardDefaults.cardColors(containerColor = Color.LightGray)
+                    ) {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = "画像 ${page + 1}",
+                                fontSize = 16.sp,
+                                color = Color.DarkGray
+                            )
+                        }
+                    }
+                }
+            }
+            
+            // ページインジケーター
+            if (imageUrls.size > 1) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp),
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    repeat(imageUrls.size) { index ->
+                        Box(
+                            modifier = Modifier
+                                .size(8.dp)
+                                .clip(RoundedCornerShape(4.dp))
+                                .background(
+                                    if (index == pagerState.currentPage) LaLigaRed
+                                    else Color.LightGray
+                                )
+                        )
+                        if (index < imageUrls.size - 1) {
+                            Spacer(modifier = Modifier.width(4.dp))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/presentation/screen/NewsListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screen/NewsListScreen.kt
@@ -3,6 +3,7 @@ package presentation.screen
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -11,12 +12,17 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import presentation.component.NewsItemCard
+import presentation.viewmodel.NewsListViewModel
 import theme.LaLigaRed
 import theme.White
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NewsListScreen() {
+    val viewModel = remember { NewsListViewModel() }
+    val state = viewModel.state
+    
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -39,17 +45,68 @@ fun NewsListScreen() {
         )
         
         // メインコンテンツエリア
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(16.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(
-                text = "ニュース一覧\n（サンプルデータは次の段階で追加）",
-                fontSize = 16.sp,
-                color = Color.Gray
-            )
+        when {
+            state.isLoading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(color = LaLigaRed)
+                }
+            }
+            
+            state.error != null -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = "エラーが発生しました",
+                            fontSize = 16.sp,
+                            color = Color.Red
+                        )
+                        Text(
+                            text = state.error,
+                            fontSize = 14.sp,
+                            color = Color.Gray
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Button(
+                            onClick = { viewModel.refresh() },
+                            colors = ButtonDefaults.buttonColors(containerColor = LaLigaRed)
+                        ) {
+                            Text("再試行", color = White)
+                        }
+                    }
+                }
+            }
+            
+            state.articles.isEmpty() -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "ニュースがありません",
+                        fontSize = 16.sp,
+                        color = Color.Gray
+                    )
+                }
+            }
+            
+            else -> {
+                LazyColumn {
+                    items(state.articles) { article ->
+                        NewsItemCard(
+                            article = article,
+                            onClick = {
+                                // TODO: 詳細画面への遷移（段階3で実装）
+                            }
+                        )
+                    }
+                }
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/presentation/screen/NewsListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screen/NewsListScreen.kt
@@ -19,7 +19,9 @@ import theme.White
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun NewsListScreen() {
+fun NewsListScreen(
+    onNewsClick: (String) -> Unit = {}
+) {
     val viewModel = remember { NewsListViewModel() }
     val state = viewModel.state
     
@@ -101,7 +103,7 @@ fun NewsListScreen() {
                         NewsItemCard(
                             article = article,
                             onClick = {
-                                // TODO: 詳細画面への遷移（段階3で実装）
+                                onNewsClick(article.id)
                             }
                         )
                     }

--- a/composeApp/src/commonMain/kotlin/presentation/state/NewsListState.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/state/NewsListState.kt
@@ -1,0 +1,9 @@
+package presentation.state
+
+import data.model.NewsArticle
+
+data class NewsListState(
+    val isLoading: Boolean = false,
+    val articles: List<NewsArticle> = emptyList(),
+    val error: String? = null
+)

--- a/composeApp/src/commonMain/kotlin/presentation/viewmodel/NewsListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/viewmodel/NewsListViewModel.kt
@@ -1,0 +1,48 @@
+package presentation.viewmodel
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import data.repository.NewsRepository
+import data.repository.SampleNewsRepository
+import presentation.state.NewsListState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class NewsListViewModel(
+    private val repository: NewsRepository = SampleNewsRepository()
+) {
+    var state by mutableStateOf(NewsListState())
+        private set
+
+    private val viewModelScope = CoroutineScope(Dispatchers.Main)
+
+    init {
+        loadNews()
+    }
+
+    private fun loadNews() {
+        state = state.copy(isLoading = true, error = null)
+        
+        viewModelScope.launch {
+            try {
+                val articles = repository.getNewsList()
+                state = state.copy(
+                    isLoading = false,
+                    articles = articles,
+                    error = null
+                )
+            } catch (e: Exception) {
+                state = state.copy(
+                    isLoading = false,
+                    error = e.message ?: "不明なエラーが発生しました"
+                )
+            }
+        }
+    }
+
+    fun refresh() {
+        loadNews()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ compose-plugin = "1.6.11"
 junit = "4.13.2"
 kotlin = "2.0.0"
 kotlinx-coroutines = "1.8.1"
+navigation-compose = "2.7.7"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -27,6 +28,7 @@ androidx-material = { group = "com.google.android.material", name = "material", 
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-compose" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ androidx-test-junit = "1.2.1"
 compose-plugin = "1.6.11"
 junit = "4.13.2"
 kotlin = "2.0.0"
+kotlinx-coroutines = "1.8.1"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -25,6 +26,7 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 androidx-material = { group = "com.google.android.material", name = "material", version.ref = "androidx-material" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/iosApp/.gitignore
+++ b/iosApp/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/iosApp/LaLigaNews.xcodeproj/project.pbxproj
+++ b/iosApp/LaLigaNews.xcodeproj/project.pbxproj
@@ -1,0 +1,398 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A8E13EDB2C4E8D0A000A8B8D /* LaLigaNewsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E13EDA2C4E8D0A000A8B8D /* LaLigaNewsApp.swift */; };
+		A8E13EDD2C4E8D0A000A8B8D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E13EDC2C4E8D0A000A8B8D /* ContentView.swift */; };
+		A8E13EDF2C4E8D0C000A8B8D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A8E13EDE2C4E8D0C000A8B8D /* Assets.xcassets */; };
+		A8E13EE22C4E8D0C000A8B8D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A8E13EE12C4E8D0C000A8B8D /* Preview Assets.xcassets */; };
+		A8E13EEA2C4E8D2D000A8B8D /* ComposeApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8E13EE92C4E8D2D000A8B8D /* ComposeApp.framework */; };
+		A8E13EEB2C4E8D2D000A8B8D /* ComposeApp.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A8E13EE92C4E8D2D000A8B8D /* ComposeApp.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		A8E13EEC2C4E8D2D000A8B8D /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				A8E13EEB2C4E8D2D000A8B8D /* ComposeApp.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		A8E13ED72C4E8D0A000A8B8D /* LaLigaNews.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LaLigaNews.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A8E13EDA2C4E8D0A000A8B8D /* LaLigaNewsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaLigaNewsApp.swift; sourceTree = "<group>"; };
+		A8E13EDC2C4E8D0A000A8B8D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		A8E13EDE2C4E8D0C000A8B8D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A8E13EE12C4E8D0C000A8B8D /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		A8E13EE32C4E8D0C000A8B8D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A8E13EE92C4E8D2D000A8B8D /* ComposeApp.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ComposeApp.framework; path = "../composeApp/build/bin/iosSimulatorArm64/debugFramework/ComposeApp.framework"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A8E13ED42C4E8D0A000A8B8D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A8E13EEA2C4E8D2D000A8B8D /* ComposeApp.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A8E13ECE2C4E8D0A000A8B8D = {
+			isa = PBXGroup;
+			children = (
+				A8E13ED92C4E8D0A000A8B8D /* LaLigaNews */,
+				A8E13ED82C4E8D0A000A8B8D /* Products */,
+				A8E13EE82C4E8D2D000A8B8D /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		A8E13ED82C4E8D0A000A8B8D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A8E13ED72C4E8D0A000A8B8D /* LaLigaNews.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A8E13ED92C4E8D0A000A8B8D /* LaLigaNews */ = {
+			isa = PBXGroup;
+			children = (
+				A8E13EDA2C4E8D0A000A8B8D /* LaLigaNewsApp.swift */,
+				A8E13EDC2C4E8D0A000A8B8D /* ContentView.swift */,
+				A8E13EDE2C4E8D0C000A8B8D /* Assets.xcassets */,
+				A8E13EE32C4E8D0C000A8B8D /* Info.plist */,
+				A8E13EE02C4E8D0C000A8B8D /* Preview Content */,
+			);
+			path = LaLigaNews;
+			sourceTree = "<group>";
+		};
+		A8E13EE02C4E8D0C000A8B8D /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				A8E13EE12C4E8D0C000A8B8D /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		A8E13EE82C4E8D2D000A8B8D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				A8E13EE92C4E8D2D000A8B8D /* ComposeApp.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A8E13ED62C4E8D0A000A8B8D /* LaLigaNews */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A8E13EE62C4E8D0C000A8B8D /* Build configuration list for PBXNativeTarget "LaLigaNews" */;
+			buildPhases = (
+				A8E13ED32C4E8D0A000A8B8D /* Sources */,
+				A8E13ED42C4E8D0A000A8B8D /* Frameworks */,
+				A8E13ED52C4E8D0A000A8B8D /* Resources */,
+				A8E13EEC2C4E8D2D000A8B8D /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = LaLigaNews;
+			productName = LaLigaNews;
+			productReference = A8E13ED72C4E8D0A000A8B8D /* LaLigaNews.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A8E13ECF2C4E8D0A000A8B8D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1540;
+				LastUpgradeCheck = 1540;
+				ORGANIZATIONNAME = LaLigaNews;
+				TargetAttributes = {
+					A8E13ED62C4E8D0A000A8B8D = {
+						CreatedOnToolsVersion = 15.4;
+					};
+				};
+			};
+			buildConfigurationList = A8E13ED22C4E8D0A000A8B8D /* Build configuration list for PBXProject "LaLigaNews" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A8E13ECE2C4E8D0A000A8B8D;
+			productRefGroup = A8E13ED82C4E8D0A000A8B8D /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A8E13ED62C4E8D0A000A8B8D /* LaLigaNews */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A8E13ED52C4E8D0A000A8B8D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A8E13EE22C4E8D0C000A8B8D /* Preview Assets.xcassets in Resources */,
+				A8E13EDF2C4E8D0C000A8B8D /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A8E13ED32C4E8D0A000A8B8D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A8E13EDD2C4E8D0A000A8B8D /* ContentView.swift in Sources */,
+				A8E13EDB2C4E8D0A000A8B8D /* LaLigaNewsApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		A8E13EE42C4E8D0C000A8B8D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A8E13EE52C4E8D0C000A8B8D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		A8E13EE72C4E8D0C000A8B8D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"LaLigaNews/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../composeApp/build/bin/iosSimulatorArm64/debugFramework",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "ラリーガニュース";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lsqlite3",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.laliga.news;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A8E13EE82C4E8D0C000A8B8D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"LaLigaNews/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../composeApp/build/bin/iosSimulatorArm64/releaseFramework",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "ラリーガニュース";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lsqlite3",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.laliga.news;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A8E13ED22C4E8D0A000A8B8D /* Build configuration list for PBXProject "LaLigaNews" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A8E13EE42C4E8D0C000A8B8D /* Debug */,
+				A8E13EE52C4E8D0C000A8B8D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A8E13EE62C4E8D0C000A8B8D /* Build configuration list for PBXNativeTarget "LaLigaNews" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A8E13EE72C4E8D0C000A8B8D /* Debug */,
+				A8E13EE82C4E8D0C000A8B8D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A8E13ECF2C4E8D0A000A8B8D /* Project object */;
+}

--- a/iosApp/LaLigaNews/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/iosApp/LaLigaNews/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iosApp/LaLigaNews/Assets.xcassets/Contents.json
+++ b/iosApp/LaLigaNews/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iosApp/LaLigaNews/ContentView.swift
+++ b/iosApp/LaLigaNews/ContentView.swift
@@ -1,0 +1,18 @@
+import UIKit
+import SwiftUI
+import ComposeApp
+
+struct ComposeView: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> UIViewController {
+        MainViewControllerKt.MainViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+}
+
+struct ContentView: View {
+    var body: some View {
+        ComposeView()
+                .ignoresSafeArea(.keyboard) // Compose has own keyboard handler
+    }
+}

--- a/iosApp/LaLigaNews/LaLigaNewsApp.swift
+++ b/iosApp/LaLigaNews/LaLigaNewsApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct LaLigaNewsApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/iosApp/LaLigaNews/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/iosApp/LaLigaNews/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iosApp/Package.swift
+++ b/iosApp/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "LaLigaNewsApp",
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .executableTarget(
+            name: "LaLigaNewsApp"),
+    ]
+)

--- a/iosApp/Sources/main.swift
+++ b/iosApp/Sources/main.swift
@@ -1,0 +1,4 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+
+print("Hello, world!")


### PR DESCRIPTION
## 概要
段階2のサンプルデータ表示機能と段階3のニュース詳細画面機能を実装しました。

## 実装内容

### 段階2: データ表示機能（✅ 完了）
- **データモデル作成**: `NewsArticle`データクラス（id, title, summary, imageUrl, publishDate）
- **Repository層実装**: `NewsRepository`インターフェース、`SampleNewsRepository`実装クラス
- **MVVM アーキテクチャ導入**: `NewsListViewModel`、`NewsListState`でUI状態管理
- **UI コンポーネント**: `NewsItemCard`でカード型レイアウト実装
- **サンプルデータ**: ラリーガ関連の日本語ニュース記事10件

### 段階3: 詳細画面機能（✅ 完了）
- **拡張データモデル**: `NewsArticle`に詳細情報追加（content, imageUrls, source等）
- **詳細画面実装**: `NewsDetailScreen`コンポーザブル
- **カスタムナビゲーション**: iOS互換性を考慮した独自実装
- **画像スライドショー**: `HorizontalPager`を使用した複数画像表示
- **記事メタデータ表示**: 公開日時、ソース、翻訳情報
- **エラーハンドリング**: 記事が見つからない場合の処理

## 技術的な詳細
- **UIフレームワーク**: Compose Multiplatform
- **アーキテクチャ**: MVVM + Repository パターン
- **ナビゲーション**: カスタム実装（navigation-compose未使用）
- **非同期処理**: Kotlin Coroutines
- **実験的API**: ExperimentalFoundationApi（HorizontalPager）

## 動作確認
- ✅ Android Debug APKビルド成功
- ✅ iOS シミュレータでの動作確認完了
- ✅ ニュース一覧から詳細画面への遷移
- ✅ 詳細画面での全機能の動作確認
- ✅ 戻るボタンでの画面遷移

## スクリーンショット
- 一覧画面: 10件のニュースカードが表示
- 詳細画面: タイトル、画像、メタデータ、本文が正しく表示
- エラー状態: 適切なエラーメッセージとリトライ機能

## Test plan
### 段階2のテスト
- [x] ニュース一覧画面にサンプルデータ10件が表示されること
- [x] 各ニュースカードにタイトル、要約、日付が表示されること
- [x] ローディング状態とエラー状態の表示が動作すること

### 段階3のテスト
- [x] ニュースカードをタップして詳細画面に遷移すること
- [x] 詳細画面にタイトル、本文、画像が表示されること
- [x] 複数画像がある場合、スライドショーが動作すること
- [x] 記事メタデータ（日時、ソース）が表示されること
- [x] 戻るボタンで一覧画面に戻れること
- [x] 存在しない記事IDでエラー表示されること

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>